### PR TITLE
Effort completion

### DIFF
--- a/volunteer-stl-React/src/components/AccountPage.jsx
+++ b/volunteer-stl-React/src/components/AccountPage.jsx
@@ -278,7 +278,7 @@ export default function AccountPage({ user }) {
 
             </section>
 
-            <section>
+              <section>
               <div className="flex justify-between items-center mb-4">
                 <h3 className="text-2xl font-bold">Efforts {currUser.firstName} Created</h3>
 

--- a/volunteer-stl-React/src/components/EffortCard.jsx
+++ b/volunteer-stl-React/src/components/EffortCard.jsx
@@ -3,12 +3,14 @@ import { Link } from 'react-router-dom';
 
 export default function EffortCard({ effort }) {
 
-  const start = new Date(effort.startTime);
+  const eventTime = new Date(effort.endTime);
+  const hasPassed = eventTime.getTime() <= Date.now();
+  console.log(hasPassed ? "past" : "upcoming");
 
   return (
-    <Link to={`/effort/${effort.effortId}`} className="flex flex-col border-[#8E0020] border-2 rounded-md w-full my-10 p-2 bg-white hover:border-[#D4B82F] transition-colors">
+    <Link to={`/effort/${effort.effortId}`} className="flex flex-col border-[#8E0020] border-2 rounded-md w-full h-90 my-10 p-2 bg-white hover:border-[#D4B82F] transition-colors">
 
-      <img src={`http://localhost:8080${effort.imageUrl}`} alt="Effort picture uploaded by user" className="w-full h-58 object-cover rounded-md" />
+      <img src={`http://localhost:8080${effort.imageUrl}`} alt="Effort picture uploaded by user" className={`w-full h-58 object-cover rounded-md ${hasPassed && 'grayscale-80'}`} />
 
       <div className="p-3">
         <h3 className='font-semibold text-lg truncate'>{effort.effortName}</h3>

--- a/volunteer-stl-React/src/components/EffortCard.jsx
+++ b/volunteer-stl-React/src/components/EffortCard.jsx
@@ -1,11 +1,9 @@
-import volunteerImage from '../images/volunteer.jpg';
 import { Link } from 'react-router-dom';
 
 export default function EffortCard({ effort }) {
 
   const eventTime = new Date(effort.endTime);
   const hasPassed = eventTime.getTime() <= Date.now();
-  console.log(hasPassed ? "past" : "upcoming");
 
   return (
     <Link to={`/effort/${effort.effortId}`} className="flex flex-col border-[#8E0020] border-2 rounded-md w-full h-90 my-10 p-2 bg-white hover:border-[#D4B82F] transition-colors">

--- a/volunteer-stl-React/src/components/EffortsDashboard.jsx
+++ b/volunteer-stl-React/src/components/EffortsDashboard.jsx
@@ -86,7 +86,7 @@ export default function EffortsDashboard({ allEfforts, user, sidebarOpen, conver
       <div>
         < EffortFilterSection setFilterOption={setFilterOption} search={search} setSearch={setSearch} setSortType={setSortType} />
 
-        <div className="bg-[#F2F2F2] grid gap-x-6 gap-y-0 p-4 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+        <div className="bg-[#F2F2F2] grid gap-x-6 gap-y-0 p-4 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 h-dvh">
           {filterOption === "Efforts" && (filteredEfforts.length > 0 ? (
             filteredEfforts.map((effort) => (
               <EffortCard key={effort.id || effort.effortId} effort={effort} />

--- a/volunteer-stl-React/src/components/Settings.jsx
+++ b/volunteer-stl-React/src/components/Settings.jsx
@@ -1,7 +1,12 @@
+import { useNavigate } from "react-router-dom";
+
 export default function Settings({ user, setUser }) {
+
+  const nav = useNavigate();
 
   const handleSignout = () => {
     setUser(null);
+    nav('/');
   };
 
   return (

--- a/volunteer-stl/src/main/java/com/unit_2_project/volunteer_stl/controllers/EffortController.java
+++ b/volunteer-stl/src/main/java/com/unit_2_project/volunteer_stl/controllers/EffortController.java
@@ -129,8 +129,8 @@ public class EffortController {
         }
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<?> getEffortById(@PathVariable int id) {
+    @GetMapping("/by-id")
+    public ResponseEntity<?> getEffortById(@RequestParam int id) {
         Effort effort = effortRepository.findById(id)
                 .orElse(null);
 

--- a/volunteer-stl/src/main/java/com/unit_2_project/volunteer_stl/controllers/EffortController.java
+++ b/volunteer-stl/src/main/java/com/unit_2_project/volunteer_stl/controllers/EffortController.java
@@ -168,7 +168,7 @@ public class EffortController {
 
     @GetMapping
     public List<EffortRetrievalDTO> getAllEfforts(){
-        List<Effort> efforts = effortRepository.findAllByOrderByStartTimeAsc();
+        List<Effort> efforts = effortRepository.findAllByEndTimeAfterOrderByStartTimeAsc(LocalDateTime.now());
         List<EffortRetrievalDTO> effortDTOs = new ArrayList<>();
 
         for(Effort effort: efforts){

--- a/volunteer-stl/src/main/java/com/unit_2_project/volunteer_stl/controllers/UserEffortController.java
+++ b/volunteer-stl/src/main/java/com/unit_2_project/volunteer_stl/controllers/UserEffortController.java
@@ -100,12 +100,12 @@ public class UserEffortController {
     }
 
     @GetMapping("/get-organized-efforts")
-    public List<EffortRetrievalDTO> getCompletedEffortsByUser(@RequestParam int userId){
+    public List<EffortRetrievalDTO> getOrganizedEffortsByUser(@RequestParam int userId){
 
         Optional<User> optionalUser = userRepository.findById(userId);
         User organizer = optionalUser.get();
 
-        List<Effort> efforts = effortRepository.findAllByOrganizer(organizer);
+        List<Effort> efforts = effortRepository.findAllByOrganizerOrderByEndTimeDesc(organizer);
         List<EffortRetrievalDTO> effortDTOs = new ArrayList<>();
 
         for(Effort effort: efforts){

--- a/volunteer-stl/src/main/java/com/unit_2_project/volunteer_stl/controllers/UserEffortController.java
+++ b/volunteer-stl/src/main/java/com/unit_2_project/volunteer_stl/controllers/UserEffortController.java
@@ -76,9 +76,27 @@ public class UserEffortController {
 
     @GetMapping("/count-completed-efforts")
     public int getCountCompletedEffortsByUser(@RequestParam int userId){
-        userEffortRepository.findAllByUserId(userId);
+        List<UserEffort> allUserEffortsByUser = userEffortRepository.findAllByUserId(userId);
+        int count = 0;
+        //List<Effort> allEffortsUserRegistered = new ArrayList<>();
 
-        return userEffortRepository.countByStatus("completed");
+        for(UserEffort userEffort : allUserEffortsByUser){
+
+            Optional <Effort> optionalEffort = effortRepository.findById(userEffort.getEffort().getId());
+            if(optionalEffort.isPresent()){
+                //allEffortsUserRegistered.add(optionalEffort.get());
+                Effort effort = optionalEffort.get();
+                if(effort.getEndTime().isBefore(LocalDateTime.now())){
+                    count++;
+                }
+            }
+        }
+
+        return count;
+
+
+
+        //add count of organized efforts
     }
 
     @GetMapping("/get-organized-efforts")

--- a/volunteer-stl/src/main/java/com/unit_2_project/volunteer_stl/repositories/EffortRepository.java
+++ b/volunteer-stl/src/main/java/com/unit_2_project/volunteer_stl/repositories/EffortRepository.java
@@ -5,6 +5,7 @@ import com.unit_2_project.volunteer_stl.models.UserEffort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.unit_2_project.volunteer_stl.models.Effort;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface EffortRepository extends JpaRepository<Effort, Integer> {
@@ -12,4 +13,9 @@ public interface EffortRepository extends JpaRepository<Effort, Integer> {
     List<Effort> findAllByOrganizer(User organizer);
 
     List<Effort> findAllByOrderByStartTimeAsc();
+
+    List<Effort> findAllByEndTimeBefore(LocalDateTime now);
+    // returns completed efforts
+    List<Effort> findAllByEndTimeAfterOrderByStartTimeAsc(LocalDateTime now);
+    // returns active/upcoming efforts
 }

--- a/volunteer-stl/src/main/java/com/unit_2_project/volunteer_stl/repositories/EffortRepository.java
+++ b/volunteer-stl/src/main/java/com/unit_2_project/volunteer_stl/repositories/EffortRepository.java
@@ -11,6 +11,7 @@ import java.util.List;
 public interface EffortRepository extends JpaRepository<Effort, Integer> {
     int countByOrganizer(User user);
     List<Effort> findAllByOrganizer(User organizer);
+    List<Effort> findAllByOrganizerOrderByEndTimeDesc(User organizer);
 
     List<Effort> findAllByOrderByStartTimeAsc();
 


### PR DESCRIPTION
Created methods to retrieve only efforts that are still active (with an end time before the current time). Updated EffortDashboard to only display active efforts. Efforts that are inactive now have a display image with an 80% grayscale filter applied. Completed efforts stat on AccountPage now returns an accurate count of all efforts a user was registered for that are inactive (will have to update this in the future to only return a count of inactive efforts that have an associated userEffort instance with a status of "completed"). User is no directed to '/' when signed out.